### PR TITLE
fix(mix): set `emqx_vsn` compile info

### DIFF
--- a/build
+++ b/build
@@ -240,6 +240,11 @@ export_release_vars() {
       exit 1
   esac
   export MIX_ENV="$profile"
+  # At this time, Mix provides no easy way to pass `erl_opts' to
+  # dependencies.  The workaround is to set this variable before
+  # compiling the project, so that `emqx_release.erl' picks up
+  # `emqx_vsn' as if it was compiled by rebar3.
+  export ERL_COMPILER_OPTIONS="[{compile_info,[{emqx_vsn,\"${PKG_VSN}\"}]}]"
 }
 
 log "building artifact=$ARTIFACT for profile=$PROFILE"


### PR DESCRIPTION
Currently, `emqx_release.erl` depends on the `erl_opts` option
`compile_info` being set by Rebar3 to include `{emqx_vsn, $PKG_VSN}`
to report the version, for instance, in `emqx ctl status`.

Since Mix does not provide a simple way to pass `erl_opts` to Rebar3
dependencies without creating a `mix.exs` file, the workaround is to
set the environment variable `ERL_COMPILER_OPTIONS` to include that
value before invoking the Erlang compiler on the Rebar3 dependencies.

