### PR TITLE
fix(ctl): fix formatting when printing messages without arguments

### DIFF
--- a/apps/emqx/src/emqx_ctl.erl
+++ b/apps/emqx/src/emqx_ctl.erl
@@ -42,8 +42,7 @@
         ]).
 
 %% Exports mainly for test cases
--export([ format/1
-        , format/2
+-export([ format/2
         , format_usage/1
         , format_usage/2
         ]).
@@ -152,10 +151,6 @@ usage(UsageList) ->
 -spec(usage(cmd_params(), cmd_descr()) -> ok).
 usage(CmdParams, Desc) ->
     io:format(format_usage(CmdParams, Desc)).
-
--spec(format(io:format()) -> string()).
-format(Msg) ->
-    lists:flatten(io_lib:format("~ts", [Msg])).
 
 -spec(format(io:format(), [term()]) -> string()).
 format(Format, Args) ->

--- a/apps/emqx/src/emqx_ctl.erl
+++ b/apps/emqx/src/emqx_ctl.erl
@@ -139,7 +139,7 @@ help() ->
 
 -spec(print(io:format()) -> ok).
 print(Msg) ->
-    io:format("~ts", [format(Msg)]).
+    io:format("~ts", [format(Msg, [])]).
 
 -spec(print(io:format(), [term()]) -> ok).
 print(Format, Args) ->
@@ -243,4 +243,3 @@ zip_cmd([X | Xs], [Y | Ys]) -> [{X, Y} | zip_cmd(Xs, Ys)];
 zip_cmd([X | Xs], []) -> [{X, ""} | zip_cmd(Xs, [])];
 zip_cmd([], [Y | Ys]) -> [{"", Y} | zip_cmd([], Ys)];
 zip_cmd([], []) -> [].
-

--- a/apps/emqx/test/emqx_ctl_SUITE.erl
+++ b/apps/emqx/test/emqx_ctl_SUITE.erl
@@ -110,7 +110,7 @@ mock_print() ->
     %% proxy usage/1,2 and print/1,2 to format_xx/1,2 funcs
     catch meck:unload(emqx_ctl),
     meck:new(emqx_ctl, [non_strict, passthrough]),
-    meck:expect(emqx_ctl, print, fun(Arg) -> emqx_ctl:format(Arg) end),
+    meck:expect(emqx_ctl, print, fun(Arg) -> emqx_ctl:format(Arg, []) end),
     meck:expect(emqx_ctl, print, fun(Msg, Arg) -> emqx_ctl:format(Msg, Arg) end),
     meck:expect(emqx_ctl, usage, fun(Usages) -> emqx_ctl:format_usage(Usages) end),
     meck:expect(emqx_ctl, usage, fun(CmdParams, CmdDescr) ->

--- a/apps/emqx_gateway/test/emqx_gateway_cli_SUITE.erl
+++ b/apps/emqx_gateway/test/emqx_gateway_cli_SUITE.erl
@@ -69,7 +69,7 @@ init_per_testcase(_, Conf) ->
                      fun(L) -> emqx_ctl:format_usage(L) end),
     ok = meck:expect(emqx_ctl, print,
                      fun(Fmt) ->
-                        Self ! {fmt, emqx_ctl:format(Fmt)}
+                        Self ! {fmt, emqx_ctl:format(Fmt, [])}
                      end),
     ok = meck:expect(emqx_ctl, print,
                      fun(Fmt, Args) ->


### PR DESCRIPTION
Without passing an empty argument list to `emqx_ctl:print`, formatting
instructions like `~n` are being printed literally.

```
Ignore.~nJoin the cluster successfully.~nCluster status: #{running_nodes =>
                      ['emqx@emqx-0.int.thalesmg','emqx@emqx-1.int.thalesmg',
                       'emqx@emqx-2.int.thalesmg','emqx@emqx-3.int.thalesmg',
                       'emqx@emqx-4.int.thalesmg'],
                  stopped_nodes => []}
```

