### PR TITLE
fix(helm): fix service name default value in `values.yaml`

### DIFF
--- a/deploy/charts/emqx/values.yaml
+++ b/deploy/charts/emqx/values.yaml
@@ -82,7 +82,7 @@ emqxConfig:
   EMQX_CLUSTER__DISCOVERY: "k8s"
   EMQX_CLUSTER__K8S__APP_NAME: "{{ .Release.Name }}"
   EMQX_CLUSTER__K8S__APISERVER: "https://kubernetes.default.svc:443"
-  EMQX_CLUSTER__K8S__SERVICE_NAME: "{{ .Release.Name }}-headless"
+  EMQX_CLUSTER__K8S__SERVICE_NAME: "{{ .Release.Name }}-{{ .Chart.Name }}-headless"
   EMQX_CLUSTER__K8S__NAMESPACE: "{{ .Release.Namespace }}"
   ## The address type is used to extract host from k8s service.
   ## Value: ip | dns | hostname


### PR DESCRIPTION
The headless service name defined in `service.yaml` uses
`{{ emqx.fullname }}-headless` as its name, but in `values.yaml`
we have:

```yaml
emqxConfig:
  # ...
  EMQX_CLUSTER__K8S__SERVICE_NAME: "{{ .Release.Name }}-headless"
```

On a simple deployment with default values, `.Release.Name` does not
include `-emqx`, and therefore there's a mismatch between the service
name used by `ekka_cluster_k8s` discovery and the true service name.

```erlang
  1> {ok, {k8s, K8sConfig}} = ekka:env(cluster_discovery).
  {ok,{k8s,[{apiserver,"https://kubernetes.default.svc:443"},
            %% should be "thalesmg-test-emqx-headless"
            {service_name,"thalesmg-test-headless"},
            {address_type,dns},
            {app_name,"thalesmg-test"},
            {namespace,"default"},
            {suffix,"pod.cluster.local"}]}}

  2> ekka_cluster_k8s:discover(K8sConfig).
  {error,{404,
          "{\"kind\":\"Status\",\"apiVersion\":\"v1\",\"metadata\":{},\"status\":\"Failure\",\"message\":\"endpoints \\\"thalesmg-test-headless\\\" not found\",\"reason\":\"NotFound\",\"details\":{\"name\":\"thalesmg-test-headless\",\"kind\":\"endpoints\"},\"code\":404}\n"}}
```

