### PR TITLE
chore(ekka): bump ekka -> 0.8.1.10

### DIFF
--- a/CHANGES-4.3.md
+++ b/CHANGES-4.3.md
@@ -25,6 +25,10 @@ File format:
 
 * SSL closed error bug fixed for redis client.
 
+* Improved resilience against autocluster partitioning during cluster
+  startup. [#7876]
+  [ekka-158](https://github.com/emqx/ekka/pull/158)
+
 ## v4.3.14
 
 ### Enhancements

--- a/rebar.config
+++ b/rebar.config
@@ -45,7 +45,7 @@
     , {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}}
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.8.2"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.8.5"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.9"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.8.1.10"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.5.1"}}}
     , {cuttlefish, {git, "https://github.com/emqx/cuttlefish", {tag, "v3.3.6"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "0.3.7"}}}


### PR DESCRIPTION
Improves autocluster resilience against split-brain during startup.

https://github.com/emqx/ekka/pull/158

