### PR TITLE
chore(ekka): bump ekka -> 0.12.5

### DIFF
--- a/apps/emqx/rebar.config
+++ b/apps/emqx/rebar.config
@@ -27,7 +27,7 @@
     {jiffy, {git, "https://github.com/emqx/jiffy", {tag, "1.0.5"}}},
     {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}},
     {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.1"}}},
-    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.4"}}},
+    {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.5"}}},
     {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}},
     {hocon, {git, "https://github.com/emqx/hocon.git", {tag, "0.27.5"}}},
     {pbkdf2, {git, "https://github.com/emqx/erlang-pbkdf2.git", {tag, "2.0.4"}}},

--- a/mix.exs
+++ b/mix.exs
@@ -55,7 +55,7 @@ defmodule EMQXUmbrella.MixProject do
       {:cowboy, github: "emqx/cowboy", tag: "2.9.0", override: true},
       {:esockd, github: "emqx/esockd", tag: "5.9.1", override: true},
       {:mria, github: "emqx/mria", tag: "0.2.4", override: true},
-      {:ekka, github: "emqx/ekka", tag: "0.12.4", override: true},
+      {:ekka, github: "emqx/ekka", tag: "0.12.5", override: true},
       {:gen_rpc, github: "emqx/gen_rpc", tag: "2.8.1", override: true},
       {:minirest, github: "emqx/minirest", tag: "1.2.13", override: true},
       {:ecpool, github: "emqx/ecpool", tag: "0.5.2"},

--- a/rebar.config
+++ b/rebar.config
@@ -54,7 +54,7 @@
     , {cowboy, {git, "https://github.com/emqx/cowboy", {tag, "2.9.0"}}}
     , {esockd, {git, "https://github.com/emqx/esockd", {tag, "5.9.1"}}}
     , {mria, {git, "https://github.com/emqx/mria", {tag, "0.2.4"}}}
-    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.4"}}}
+    , {ekka, {git, "https://github.com/emqx/ekka", {tag, "0.12.5"}}}
     , {gen_rpc, {git, "https://github.com/emqx/gen_rpc", {tag, "2.8.1"}}}
     , {minirest, {git, "https://github.com/emqx/minirest", {tag, "1.2.13"}}}
     , {ecpool, {git, "https://github.com/emqx/ecpool", {tag, "0.5.2"}}}


### PR DESCRIPTION
Improves autocluster resilience against split-brain during startup.

https://github.com/emqx/ekka/pull/160

